### PR TITLE
Fix protocol error with https in front of site.url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,7 +21,7 @@
 title: Odin - A Jekyll Knowledge Base Theme
 description: Odin is a simple to setup and use Jekyll theme for help desks and knowledge bases. Hosts for free on Github Pages!
 baseurl: /odin # the subpath of your site, e.g. /support
-url: teaguns.github.io # the base hostname & protocol for your site, e.g. http://example.com
+url: https://teaguns.github.io # the base hostname AND PROTOCOL for your site, e.g. http://example.com
 permalink: /:categories/:title
 
 content_type: Knowledge Base #Define whether this is a knowledge base, help center, or something else

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,12 +1,12 @@
 <nav class="container grid-xl navbar">
   <div class="flex-vertical-center hide-sm">
-    <a style="width: 20%;" href="https://{{ site.url }}{{ site.baseurl }}" class="logo">
+    <a style="width: 20%;" href="{{ site.url }}{{ site.baseurl }}" class="logo">
       <img style="max-width: 100%;" src="{{ site.baseurl }}/assets/{{ site.brand_logo }}"/>
     </a>
     <p class="m-0 ml-2 text-light d-inline">{{ site.content_type }}</p>
   </div>
   <div class="text-center show-sm">
-    <a style="width: 100%;" href="https://{{ site.url }}{{ site.baseurl }}" class="logo flex-centered">
+    <a style="width: 100%;" href="{{ site.url }}{{ site.baseurl }}" class="logo flex-centered">
       <img style="max-width: 150px;" src="{{ site.baseurl }}/assets/{{ site.brand_logo }}"/>
     </a>
     <p class="m-0 text-light">{{ site.content_type }}</p>

--- a/_layouts/category.html
+++ b/_layouts/category.html
@@ -13,7 +13,7 @@ layout: default
       <div class="column col-12">
         <ul class="breadcrumb">
           <li class="breadcrumb-item">
-            <a href="https://{{ site.url }}{{ site.baseurl }}">Help Center Home</a>
+            <a href="{{ site.url }}{{ site.baseurl }}">Help Center Home</a>
           </li>
           <li class="breadcrumb-item">
             <a href="#">{{ page_category.name }}</a>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -15,7 +15,7 @@ layout: default
         <div class="column col-12">
           <ul class="breadcrumb">
             <li class="breadcrumb-item">
-              <a href="https://{{ site.url }}{{ site.baseurl }}">Help Center Home</a>
+              <a href="{{ site.url }}{{ site.baseurl }}">Help Center Home</a>
             </li>
             <li class="breadcrumb-item">
               <a href="../{{ page.category }}">{{ page_category.name }}</a>


### PR DESCRIPTION
According to the `_config.yml` file, the `url` variable
should include the protocol (e.g. `https://`). However,
at other places thoughout the code, you used
`https://{{ site.url }}`, which lead to some wierd issues
when hosting with a custom domain on github (mainly issues
where some resources are requested using http instead of https).

I hope this is the way `site.url` was intended. We would have
to agree on where to put the protocol. For now, it has to be
added to the `url` variable. Thus, we have to drop any `https://`
in front of `{{ site.url }}`.