### PR TITLE
Fix Facebook Link in Footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -23,7 +23,7 @@
 
             {% if site.facebook_page == null %}
             {% else %}
-            <a href="{{ site.facebook_page}}"><i class='uil uil-facebook' target="_blank"></i></a>
+            <a href="https://www.facebook.com/{{ site.facebook_page}}" target="_blank"><i class='uil uil-facebook'></i></a>
             {% endif %}
 
             {% if site.email == null %}


### PR DESCRIPTION
A couple of updates to the Footer:
 
- Added a base url for the Facebook Link
- Facebook Link now opens in a new tab like other links