### PR TITLE
Edit category post count

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,11 +19,13 @@ title: Home
               <div class="card card-link">
                 <div class="card-body text-center my-4">
                   <h5 class="text-bold">{{ page_category.name }}</h5>
-                      
-                  {% if category[1].size == 1 %}
-                  <p class="m-0">{{ category | last | size }} article</p>
+                  {% assign post_count = site.categories[category_name].size %}
+                  {% if post_count == nil %}
+                    <p class="m-0">No article yet</p>
+                  {% elsif post_count == 1 %}
+                    <p class="m-0">{{ post_count }} article</p>
                   {% else %}
-                  <p class="m-0">{{ category | last | size }} articles</p>
+                    <p class="m-0">{{ post_count }} articles</p>
                   {% endif %}
                 </div>
               </div>


### PR DESCRIPTION
Fix https://github.com/TeaGuns/odin/issues/2
The article count is false. I create a variable name `post_count` out of `site.categories[category_name].size`. Then assign if the blog has `nil` or `1` or `more than 1` article.
This just fix category's post count, not subcategory's post count.

note: Thanks for the beautiful theme. I used it in my blog at https://teamkhunglong.com. But I don't use subcategory, so my changes need to be reviewed carefully.  